### PR TITLE
Fix plugin paths to be compatible with fingerprinters

### DIFF
--- a/release/viewer.js
+++ b/release/viewer.js
@@ -1,12 +1,12 @@
 var pdfjs_version    = '1.8.355',
     ViewerJS_version = '0.6.6';
 
-function loadPlugin( pluginName, callback ) {
+function loadPlugin( pluginFile, callback ) {
     "use strict";
     var script    = document.createElement('script');
     script.async  = false;
     script.onload = callback;
-    script.src    = pluginName + '.js';
+    script.src    = pluginFile;
     script.type   = 'text/javascript';
     document.head.appendChild(script);
 }
@@ -696,7 +696,7 @@ function Viewer( viewerPlugin, parameters ) {
                     supportsFileExtension: function ( extension ) {
                         return (odfFileExtensions.indexOf(extension) !== -1);
                     },
-                    path:                  "./ODFViewerPlugin",
+                    path:                  "./ODFViewerPlugin.js",
                     getClass:              function () {
                         return ODFViewerPlugin;
                     }
@@ -709,7 +709,7 @@ function Viewer( viewerPlugin, parameters ) {
                 supportsFileExtension: function ( extension ) {
                     return (extension === 'pdf');
                 },
-                path:                  "./PDFViewerPlugin",
+                path:                  "./PDFViewerPlugin.js",
                 getClass:              function () {
                     return PDFViewerPlugin;
                 }
@@ -735,7 +735,7 @@ function Viewer( viewerPlugin, parameters ) {
                     supportsFileExtension: function ( extension ) {
                         return (imageFileExtensions.indexOf(extension) !== -1);
                     },
-                    path:                  "./ImageViewerPlugin",
+                    path:                  "./ImageViewerPlugin.js",
                     getClass:              function () {
                         return ImageViewerPlugin;
                     }
@@ -775,7 +775,7 @@ function Viewer( viewerPlugin, parameters ) {
                     supportsFileExtension: function ( extension ) {
                         return (multimediaFileExtensions.indexOf(extension) !== -1);
                     },
-                    path:                  "./MultimediaViewerPlugin",
+                    path:                  "./MultimediaViewerPlugin.js",
                     getClass:              function () {
                         return MultimediaViewerPlugin;
                     }
@@ -789,7 +789,7 @@ function Viewer( viewerPlugin, parameters ) {
             supportsFileExtension: function () {
                 return true;
             },
-            path:                  "./UnknownFilePlugin",
+            path:                  "./UnknownFilePlugin.js",
             getClass:              function () {
                 return UnknownFilePlugin;
             }

--- a/src/PluginLoader.js
+++ b/src/PluginLoader.js
@@ -58,7 +58,7 @@
                     supportsFileExtension: function ( extension ) {
                         return (odfFileExtensions.indexOf(extension) !== -1);
                     },
-                    path:                  "./ODFViewerPlugin",
+                    path:                  "./ODFViewerPlugin.js",
                     getClass:              function () {
                         return ODFViewerPlugin;
                     }
@@ -71,7 +71,7 @@
                 supportsFileExtension: function ( extension ) {
                     return (extension === 'pdf');
                 },
-                path:                  "./PDFViewerPlugin",
+                path:                  "./PDFViewerPlugin.js",
                 getClass:              function () {
                     return PDFViewerPlugin;
                 }
@@ -97,7 +97,7 @@
                     supportsFileExtension: function ( extension ) {
                         return (imageFileExtensions.indexOf(extension) !== -1);
                     },
-                    path:                  "./ImageViewerPlugin",
+                    path:                  "./ImageViewerPlugin.js",
                     getClass:              function () {
                         return ImageViewerPlugin;
                     }
@@ -137,7 +137,7 @@
                     supportsFileExtension: function ( extension ) {
                         return (multimediaFileExtensions.indexOf(extension) !== -1);
                     },
-                    path:                  "./MultimediaViewerPlugin",
+                    path:                  "./MultimediaViewerPlugin.js",
                     getClass:              function () {
                         return MultimediaViewerPlugin;
                     }
@@ -151,7 +151,7 @@
             supportsFileExtension: function () {
                 return true;
             },
-            path:                  "./UnknownFilePlugin",
+            path:                  "./UnknownFilePlugin.js",
             getClass:              function () {
                 return UnknownFilePlugin;
             }

--- a/src/additionals.js
+++ b/src/additionals.js
@@ -1,12 +1,12 @@
 var pdfjs_version    = '1.8.355',
     ViewerJS_version = '0.6.6';
 
-function loadPlugin( pluginName, callback ) {
+function loadPlugin( pluginFile, callback ) {
     "use strict";
     var script    = document.createElement('script');
     script.async  = false;
     script.onload = callback;
-    script.src    = pluginName + '.js';
+    script.src    = pluginFile;
     script.type   = 'text/javascript';
     document.head.appendChild(script);
 }


### PR DESCRIPTION
Tools expect to find the complete file name of fingerprinted assets
in order for them to be replaced with the hashed version